### PR TITLE
Remove check on existence of payment details

### DIFF
--- a/Payum/Przelewy24/Action/CaptureAction.php
+++ b/Payum/Przelewy24/Action/CaptureAction.php
@@ -45,10 +45,6 @@ class CaptureAction extends PaymentAwareAction
 
     private function composeDetails(PaymentInterface $payment, TokenInterface $token)
     {
-        if ($payment->getDetails()) {
-            return;
-        }
-
         $order = $payment->getOrder();
 
         $details = [];


### PR DESCRIPTION
This functionality is dangerous in situation, when we are making a second payment on a modified order.
Client in some case is able to make a payment with lower price than the order is really containing.
I've removed checking on details existence. Now it will be always reloaded.
